### PR TITLE
jimt/file-activations - closing an active file will now activate the appropriate next one

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
       src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/js/all.min.js"
     ></script>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CDO IDE</title>
   </head>

--- a/src/CDOIDE/center-pane/FileNav.tsx
+++ b/src/CDOIDE/center-pane/FileNav.tsx
@@ -2,13 +2,12 @@ import React from "react";
 import "./styles/file-nav.css";
 
 import { useCDOIDEContext } from "../cdo-ide-context";
+import { sortFilesByName } from "../utils";
 
 export const FileNav = () => {
   const { project, closeFile, setActiveFile } = useCDOIDEContext();
 
-  const files = Object.values(project.files)
-    .filter((f) => f.open)
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const files = sortFilesByName(project.files, { mustBeOpen: true });
 
   return (
     <div className="files-nav-bar">

--- a/src/CDOIDE/right-pane/HTMLPreview.tsx
+++ b/src/CDOIDE/right-pane/HTMLPreview.tsx
@@ -20,7 +20,7 @@ export const HTMLPreview = ({ file }: HTMLPreviewProps) => {
     }
 
     const contents = file.contents.replace(
-      new RegExp('<link rel="stylesheet" href="([^"]+)"></style>', "g"),
+      new RegExp('<link rel="stylesheet" href="([^"]+)"/>', "g"),
       (_, styleURI) => {
         // this is tedious. Break apart the style URI and look up all folders to get the final folder ID.
         // THEN look for a file with the same name and folder and that's what we need.

--- a/src/CDOIDE/utils/index.ts
+++ b/src/CDOIDE/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./editable-file-type";
 export * from "./preview-file-type";
 export * from "./prettify";
+export * from "./sort-files-by-name";

--- a/src/CDOIDE/utils/sort-files-by-name.ts
+++ b/src/CDOIDE/utils/sort-files-by-name.ts
@@ -1,0 +1,10 @@
+import { ProjectType } from "../types";
+
+export const sortFilesByName = (
+  files: ProjectType["files"],
+  options = { mustBeOpen: true }
+) => {
+  return Object.values(files)
+    .filter((f) => !options.mustBeOpen || (f.open && options.mustBeOpen))
+    .sort((a, b) => a.name.localeCompare(b.name));
+};


### PR DESCRIPTION
If you closed the activated file, it would just keep the editor completely inactive.

Now it'll activate either the last file which was alphabetically before it, and if there are none then the next file after.

e.g., if you have these files open:

```
a.html B.HTML c.html
```

where B.HTML is active, closing it will activate a.html, since it's first. You then have this:

```
A.HTML c.html
```

where A.HTML is active. Closing it will activate c.html, since there is nothing before it. Closing `c.html` will leave no active files so the editor will clear back to empty.