### PR TITLE
jimt/replace-project - added replace project action

### DIFF
--- a/src/CDOIDE/cdo-ide-context/cdo-ide-context-project-reducer.ts
+++ b/src/CDOIDE/cdo-ide-context/cdo-ide-context-project-reducer.ts
@@ -12,6 +12,13 @@ type DefaultFolderPayload = {
 
 export const projectReducer = (project: ProjectType, action: ReducerAction) => {
   switch (action.type) {
+    case PROJECT_REDUCER_ACTIONS.REPLACE_PROJECT: {
+      const { project: newProject } = action.payload as {
+        project: ProjectType;
+      };
+
+      return newProject;
+    }
     case PROJECT_REDUCER_ACTIONS.NEW_FILE: {
       const { fileId, fileName, folderId, contents = "" } = <
         DefaultFilePayload & {

--- a/src/CDOIDE/cdo-ide-context/types.ts
+++ b/src/CDOIDE/cdo-ide-context/types.ts
@@ -1,3 +1,6 @@
+import { ProjectType } from "../types";
+export type ReplaceProjectFunction = (project: ProjectType) => void;
+
 export type SaveFileFunction = (fileId: string, contents: string) => void;
 export type CloseFileFunction = (fileId: string) => void;
 export type SetActiveFileFunction = (fileId: string) => void;

--- a/src/CDOIDE/cdo-ide-context/utils.ts
+++ b/src/CDOIDE/cdo-ide-context/utils.ts
@@ -1,11 +1,13 @@
 import { useMemo } from "react";
 import {
+  ProjectType,
   ProjectFileType,
   ProjectFolderType,
   ReducerAction,
   PROJECT_REDUCER_ACTIONS,
 } from "../types";
 import {
+  ReplaceProjectFunction,
   SaveFileFunction,
   NewFileFunction,
   RenameFileFunction,
@@ -61,6 +63,12 @@ export const useProjectUtilities = (
 ) => {
   return useMemo(() => {
     const utils = {
+      replaceProject: <ReplaceProjectFunction>((project: ProjectType) => {
+        dispatch({
+          type: PROJECT_REDUCER_ACTIONS.REPLACE_PROJECT,
+          payload: { project },
+        });
+      }),
       newFile: <NewFileFunction>(({
         fileId,
         fileName,

--- a/src/CDOIDE/left-pane/nav-bar-components/Files.tsx
+++ b/src/CDOIDE/left-pane/nav-bar-components/Files.tsx
@@ -49,7 +49,6 @@ const FilesBrowser = ({
               }
             />
           );
-
           return (
             <li key={f.id + f.open}>
               <span className="label">

--- a/src/CDOIDE/types.ts
+++ b/src/CDOIDE/types.ts
@@ -48,6 +48,7 @@ export type ReducerAction = {
 };
 
 export const PROJECT_REDUCER_ACTIONS = {
+  REPLACE_PROJECT: "REPLACE_PROJECT",
   NEW_FILE: "NEW_FILE",
   RENAME_FILE: "RENAME_FILE",
   SAVE_FILE: "SAVE_FILE",


### PR DESCRIPTION
If the project was changed externally to CDOIDE, it wasn't properly updating due to the internalProject reducer.

So this does some magic to keep it in sync.

mid-long term, it might be nice to give the action creators explicit wrappers to call setProject upon their updates, but there are other syncing issues there (i.e., setProject may fire multiple times if they're nested or we run into memoization problems). So this'll work for now.

Alternatively, we could pull the project reducer completely externally, but I feel that that's a leaky abstraction.

Ooh! Maybe wrap it up into a new hook? Something like this?

```
const [project, setProject] = useCDOIDEProject(initProject);
```

where `project` is the internal state which is managed inside the context, and `setProject` will call the `replaceProject` action? That might have potential. I'll think about it.