### PR TITLE
jimt/defined-local-project-root added @cdoide alias

### DIFF
--- a/src/CDOIDE/CDOIDE.tsx
+++ b/src/CDOIDE/CDOIDE.tsx
@@ -3,18 +3,18 @@ import {
   CDOIDEContextProvider,
   projectReducer,
   useProjectUtilities,
-} from "./cdo-ide-context";
+} from "@cdoide/cdo-ide-context";
 import {
   ProjectType,
   ConfigType,
   SetProjectFunction,
   SetConfigFunction,
-} from "./types";
+} from "@cdoide/types";
 
-import { LeftPane } from "./left-pane";
-import { CenterPane } from "./center-pane";
-import { RightPane } from "./right-pane";
-import { RunBar } from "./run-bar";
+import { LeftPane } from "@cdoide/left-pane";
+import { CenterPane } from "@cdoide/center-pane";
+import { RightPane } from "@cdoide/right-pane";
+import { RunBar } from "@cdoide/run-bar";
 
 import "./styles/cdo-ide.css";
 

--- a/src/CDOIDE/cdo-ide-context/cdo-ide-context-config-reducer.ts
+++ b/src/CDOIDE/cdo-ide-context/cdo-ide-context-config-reducer.ts
@@ -1,4 +1,4 @@
-import { ConfigType, ReducerAction } from "../types";
+import { ConfigType, ReducerAction } from "@cdoide/types";
 export const configReducer = (state: ConfigType, action: ReducerAction) => {
   switch (action.type) {
     default:

--- a/src/CDOIDE/cdo-ide-context/cdo-ide-context-project-reducer.ts
+++ b/src/CDOIDE/cdo-ide-context/cdo-ide-context-project-reducer.ts
@@ -1,6 +1,10 @@
-import { ProjectType, ReducerAction, PROJECT_REDUCER_ACTIONS } from "../types";
+import {
+  ProjectType,
+  ReducerAction,
+  PROJECT_REDUCER_ACTIONS,
+} from "@cdoide/types";
 import { findFiles, findSubFolders } from "./utils";
-import { sortFilesByName } from "../utils";
+import { sortFilesByName } from "@cdoide/utils";
 
 type DefaultFilePayload = {
   fileId: string;

--- a/src/CDOIDE/cdo-ide-context/types.ts
+++ b/src/CDOIDE/cdo-ide-context/types.ts
@@ -1,4 +1,4 @@
-import { ProjectType } from "../types";
+import { ProjectType } from "@cdoide/types";
 export type ReplaceProjectFunction = (project: ProjectType) => void;
 
 export type SaveFileFunction = (fileId: string, contents: string) => void;

--- a/src/CDOIDE/cdo-ide-context/utils.ts
+++ b/src/CDOIDE/cdo-ide-context/utils.ts
@@ -5,7 +5,7 @@ import {
   ProjectFolderType,
   ReducerAction,
   PROJECT_REDUCER_ACTIONS,
-} from "../types";
+} from "@cdoide/types";
 import {
   ReplaceProjectFunction,
   SaveFileFunction,

--- a/src/CDOIDE/center-pane/FileNav.tsx
+++ b/src/CDOIDE/center-pane/FileNav.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import "./styles/file-nav.css";
 
-import { useCDOIDEContext } from "../cdo-ide-context";
-import { sortFilesByName } from "../utils";
+import { useCDOIDEContext } from "@cdoide/cdo-ide-context";
+import { sortFilesByName } from "@cdoide/utils";
 
 export const FileNav = () => {
   const { project, closeFile, setActiveFile } = useCDOIDEContext();

--- a/src/CDOIDE/center-pane/InternalEditor.tsx
+++ b/src/CDOIDE/center-pane/InternalEditor.tsx
@@ -1,7 +1,5 @@
 import { useState, useCallback } from "react";
 
-import { useCDOIDEContext } from "../cdo-ide-context";
-
 import CodeMirror from "@uiw/react-codemirror";
 
 import { html } from "@codemirror/lang-html";
@@ -10,8 +8,9 @@ import { javascript as js } from "@codemirror/lang-javascript";
 import { json } from "@codemirror/lang-json";
 import { LanguageSupport } from "@codemirror/language";
 
-import { editableFileType, prettify } from "../utils";
-import { useEmptyEditor } from "../hooks";
+import { useCDOIDEContext } from "@cdoide/cdo-ide-context";
+import { editableFileType, prettify } from "@cdoide/utils";
+import { useEmptyEditor } from "@cdoide/hooks";
 import { EditorTheme } from "./types";
 
 const codeMirrorLangMapping: { [key: string]: LanguageSupport } = {

--- a/src/CDOIDE/center-pane/index.tsx
+++ b/src/CDOIDE/center-pane/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "./styles/center-pane.css";
 
-import { useCDOIDEContext } from "../cdo-ide-context";
+import { useCDOIDEContext } from "@cdoide/cdo-ide-context";
 
 import { FileNav } from "./FileNav";
 import InternalEditor from "./InternalEditor";

--- a/src/CDOIDE/debugger/DebuggerWrapper.tsx
+++ b/src/CDOIDE/debugger/DebuggerWrapper.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import "./styles/debugger-wrapper.css";
 
-import { useCDOIDEContext } from "../cdo-ide-context";
+import { useCDOIDEContext } from "@cdoide/cdo-ide-context";
 
 import { Debugger } from "./Debugger";
 

--- a/src/CDOIDE/hooks/useEmptyEditor.tsx
+++ b/src/CDOIDE/hooks/useEmptyEditor.tsx
@@ -1,6 +1,6 @@
-import { useCDOIDEContext } from "../cdo-ide-context";
-import { getEmptyEditor } from "../utils";
-import { ConfigType } from "../types";
+import { useCDOIDEContext } from "@cdoide/cdo-ide-context";
+import { getEmptyEditor } from "@cdoide/utils";
+import { ConfigType } from "@cdoide/types";
 export const useEmptyEditor = () => {
   const { config } = useCDOIDEContext();
   return getEmptyEditor(config);

--- a/src/CDOIDE/left-pane/NavBar.tsx
+++ b/src/CDOIDE/left-pane/NavBar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "./styles/nav-bar.css";
 
-import { useCDOIDEContext } from "../cdo-ide-context";
+import { useCDOIDEContext } from "@cdoide/cdo-ide-context";
 
 type NavBarProps = {
   setActivePane: (newActivePane: string) => void;

--- a/src/CDOIDE/left-pane/SideBar.tsx
+++ b/src/CDOIDE/left-pane/SideBar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useCDOIDEContext } from "../cdo-ide-context";
+import { useCDOIDEContext } from "@cdoide/cdo-ide-context";
 
 import "./styles/side-bar.css";
 

--- a/src/CDOIDE/left-pane/index.tsx
+++ b/src/CDOIDE/left-pane/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 import "./styles/left-pane.css";
 
-import { useCDOIDEContext } from "../cdo-ide-context";
+import { useCDOIDEContext } from "@cdoide/cdo-ide-context";
 import { NavBar } from "./NavBar";
 import { SideBar } from "./SideBar";
 import { Instructions, Files, Search } from "./nav-bar-components";

--- a/src/CDOIDE/left-pane/nav-bar-components/Files.tsx
+++ b/src/CDOIDE/left-pane/nav-bar-components/Files.tsx
@@ -3,10 +3,10 @@ import {
   useCDOIDEContext,
   getNextFileId,
   getNextFolderId,
-} from "../../cdo-ide-context";
+} from "@cdoide/cdo-ide-context";
 
-import { ProjectType } from "../../types";
-import { DEFAULT_FOLDER_ID } from "../../constants";
+import { ProjectType } from "@cdoide/types";
+import { DEFAULT_FOLDER_ID } from "@cdoide/constants";
 
 import "./styles/files.css";
 

--- a/src/CDOIDE/left-pane/nav-bar-components/Instructions.tsx
+++ b/src/CDOIDE/left-pane/nav-bar-components/Instructions.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useCDOIDEContext } from "../../cdo-ide-context";
+import { useCDOIDEContext } from "@cdoide/cdo-ide-context";
 
 import "./styles/instructions.css";
 

--- a/src/CDOIDE/right-pane/HTMLPreview.tsx
+++ b/src/CDOIDE/right-pane/HTMLPreview.tsx
@@ -1,8 +1,8 @@
 import React, { useRef, useMemo } from "react";
 
-import { useCDOIDEContext } from "../cdo-ide-context";
-import { ProjectFileType } from "../types";
-import { DEFAULT_FOLDER_ID } from "../constants";
+import { useCDOIDEContext } from "@cdoide/cdo-ide-context";
+import { ProjectFileType } from "@cdoide/types";
+import { DEFAULT_FOLDER_ID } from "@cdoide/constants";
 
 type HTMLPreviewProps = {
   file: ProjectFileType;

--- a/src/CDOIDE/right-pane/JSONPreview.tsx
+++ b/src/CDOIDE/right-pane/JSONPreview.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import "./styles/json-preview.css";
 
-import { ProjectFileType } from "../types";
+import { ProjectFileType } from "@cdoide/types";
 
 type JSONPreviewProps = {
   file: ProjectFileType;

--- a/src/CDOIDE/right-pane/JSPreview.tsx
+++ b/src/CDOIDE/right-pane/JSPreview.tsx
@@ -3,9 +3,9 @@ import Sandbox from "websandbox";
 
 import "./styles/js-preview.css";
 
-import { DebuggerWrapper } from "../debugger/DebuggerWrapper";
+import { DebuggerWrapper } from "@cdoide/debugger/DebuggerWrapper";
 
-import { ProjectFileType } from "../types";
+import { ProjectFileType } from "@cdoide/types";
 
 type JSPreviewProps = {
   file: ProjectFileType;

--- a/src/CDOIDE/right-pane/index.tsx
+++ b/src/CDOIDE/right-pane/index.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useRef, useEffect } from "react";
 import "./styles/right-pane.css";
 
-import { useCDOIDEContext } from "../cdo-ide-context";
+import { useCDOIDEContext } from "@cdoide/cdo-ide-context";
 import { HTMLPreview } from "./HTMLPreview";
 import { JSPreview } from "./JSPreview";
 import { JSONPreview } from "./JSONPreview";
 
-import { previewFileType } from "../utils";
-import { ProjectFileType } from "../types";
+import { previewFileType } from "@cdoide/utils";
+import { ProjectFileType } from "@cdoide/types";
 
 const fileTypeMap: {
   [key: string]: (args: { file: ProjectFileType }) => JSX.Element;

--- a/src/CDOIDE/utils/get-empty-editor.ts
+++ b/src/CDOIDE/utils/get-empty-editor.ts
@@ -1,4 +1,4 @@
-import { ConfigType } from "../types";
+import { ConfigType } from "@cdoide/types";
 
 import { DefaultEmptyEditor, BlankEmptyEditor } from "../DefaultEmptyEditors";
 

--- a/src/CDOIDE/utils/sort-files-by-name.ts
+++ b/src/CDOIDE/utils/sort-files-by-name.ts
@@ -1,4 +1,4 @@
-import { ProjectType } from "../types";
+import { ProjectType } from "@cdoide/types";
 
 export const sortFilesByName = (
   files: ProjectType["files"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@cdoide/*": ["./src/CDOIDE/*"]
+    },
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@cdoide": path.resolve(__dirname, "./src/CDOIDE"),
     },
   },
   build: {


### PR DESCRIPTION
I got tired of all of the relative paths, so I added in a @cdoide import to get to `./src/CDOIDE`.

I didn't want to just use `@` for fear of it conflicting in the main repo, and mapping to the root would require drilling into the directory every time anyway.