### PR TITLE
jimt/empty-project - added getEmptyProject function

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,9 @@ import "./styles/App.css";
 
 import { Config } from "./Config";
 
-import { CDOIDE } from "./CDOIDE/CDOIDE";
-import { ConfigType, ProjectType } from "./CDOIDE/types";
+import { CDOIDE } from "@cdoide/CDOIDE";
+import { ConfigType, ProjectType } from "@cdoide/types";
+import { getEmptyProject } from "@cdoide/utils";
 //import { FakeEditor } from "./FakeEditor";
 //import InternalEditor from "./CDOIDE/center-pane/InternalEditor";
 
@@ -120,7 +121,7 @@ const defaultProject: ProjectType = {
 };
 
 const App = () => {
-  const [project, setProject] = useState<ProjectType>(defaultProject);
+  const [project, setProject] = useState<ProjectType>(getEmptyProject());
   const [config, setConfig] = useState<ConfigType>(defaultConfig);
   const [showConfig, setShowConfig] = useState<"project" | "config" | "">("");
 

--- a/src/CDOIDE/utils/get-empty-project.ts
+++ b/src/CDOIDE/utils/get-empty-project.ts
@@ -1,0 +1,1 @@
+export const getEmptyProject = () => ({ files: {}, folders: {} });

--- a/src/CDOIDE/utils/index.ts
+++ b/src/CDOIDE/utils/index.ts
@@ -1,5 +1,6 @@
 export * from "./editable-file-type";
 export * from "./get-empty-editor";
+export * from "./get-empty-project";
 export * from "./preview-file-type";
 export * from "./prettify";
 export * from "./sort-files-by-name";


### PR DESCRIPTION
Adds `getEmptyProject` function to give you a usable `ProjectType` object w/o any data in it.

use it when you don't have any saved data to pass in.