### PR TITLE
jimt/type-aliases - FileId/FolderId types

### DIFF
--- a/src/CDOIDE/cdo-ide-context/cdo-ide-context-project-reducer.ts
+++ b/src/CDOIDE/cdo-ide-context/cdo-ide-context-project-reducer.ts
@@ -1,15 +1,15 @@
-import { ProjectType, ReducerAction } from "@cdoide/types";
+import { ProjectType, ReducerAction, FileId, FolderId } from "@cdoide/types";
 import { sortFilesByName } from "@cdoide/utils";
 
 import { findFiles, findSubFolders } from "./utils";
 import { PROJECT_REDUCER_ACTIONS } from "./constants";
 
 type DefaultFilePayload = {
-  fileId: string;
+  fileId: FileId;
 };
 
 type DefaultFolderPayload = {
-  folderId: string;
+  folderId: FolderId;
 };
 
 export const projectReducer = (project: ProjectType, action: ReducerAction) => {
@@ -26,7 +26,7 @@ export const projectReducer = (project: ProjectType, action: ReducerAction) => {
         DefaultFilePayload & {
           fileName: string;
           contents?: string;
-          folderId: string;
+          folderId: FolderId;
         }
       >action.payload;
 
@@ -163,9 +163,9 @@ export const projectReducer = (project: ProjectType, action: ReducerAction) => {
     }
 
     case PROJECT_REDUCER_ACTIONS.MOVE_FILE: {
-      const { fileId, folderId } = <DefaultFilePayload & { folderId: string }>(
-        action.payload
-      );
+      const { fileId, folderId } = <
+        DefaultFilePayload & { folderId: FolderId }
+      >action.payload;
       return {
         ...project,
         files: {

--- a/src/CDOIDE/cdo-ide-context/types.ts
+++ b/src/CDOIDE/cdo-ide-context/types.ts
@@ -1,25 +1,25 @@
-import { ProjectType } from "@cdoide/types";
+import { ProjectType, FileId, FolderId } from "@cdoide/types";
 export type ReplaceProjectFunction = (project: ProjectType) => void;
 
-export type SaveFileFunction = (fileId: string, contents: string) => void;
-export type CloseFileFunction = (fileId: string) => void;
-export type SetActiveFileFunction = (fileId: string) => void;
+export type SaveFileFunction = (fileId: FileId, contents: string) => void;
+export type CloseFileFunction = (fileId: FileId) => void;
+export type SetActiveFileFunction = (fileId: FileId) => void;
 
 export type NewFolderFunction = (arg: {
-  folderId: string;
+  folderId: FolderId;
   folderName: string;
-  parentId?: string;
+  parentId?: FolderId;
 }) => void;
-export type ToggleOpenFolderFunction = (folderId: string) => void;
-export type DeleteFolderFunction = (folderId: string) => void;
-export type OpenFileFunction = (fileId: string) => void;
-export type DeleteFileFunction = (fileId: string) => void;
+export type ToggleOpenFolderFunction = (folderId: FolderId) => void;
+export type DeleteFolderFunction = (folderId: FolderId) => void;
+export type OpenFileFunction = (fileId: FileId) => void;
+export type DeleteFileFunction = (fileId: FileId) => void;
 export type NewFileFunction = (arg: {
-  fileId: string;
+  fileId: FileId;
   fileName: string;
-  folderId?: string;
+  folderId?: FolderId;
   contents?: string;
 }) => void;
-export type RenameFileFunction = (fileId: string, newName: string) => void;
+export type RenameFileFunction = (fileId: FileId, newName: string) => void;
 export type RenameFolderFunction = (folderId: string, newName: string) => void;
-export type MoveFileFunction = (fileId: string, folderId: string) => void;
+export type MoveFileFunction = (fileId: FileId, folderId: FolderId) => void;

--- a/src/CDOIDE/center-pane/types.ts
+++ b/src/CDOIDE/center-pane/types.ts
@@ -1,5 +1,1 @@
-export type SaveFileFunction = (fileId: string, contents: string) => void;
-export type CloseFileFunction = (fileId: string) => void;
-export type SetActiveFileFunction = (fileId: string) => void;
-
 export type EditorTheme = "light" | "dark";

--- a/src/CDOIDE/left-pane/nav-bar-components/Files.tsx
+++ b/src/CDOIDE/left-pane/nav-bar-components/Files.tsx
@@ -5,7 +5,7 @@ import {
   getNextFolderId,
 } from "@cdoide/cdo-ide-context";
 
-import { ProjectType } from "@cdoide/types";
+import { ProjectType, FileId, FolderId } from "@cdoide/types";
 import { DEFAULT_FOLDER_ID } from "@cdoide/constants";
 import { findFolder, getErrorMessage } from "@cdoide/utils";
 
@@ -16,10 +16,10 @@ type FilesComponentProps = {
   folders: ProjectType["folders"];
   parentId?: string;
   files: ProjectType["files"];
-  newFilePrompt: (folderId?: string) => void;
-  moveFilePrompt: (fileId: string) => void;
-  renameFilePrompt: (fileId: string) => void;
-  renameFolderPrompt: (folderId: string) => void;
+  newFilePrompt: (folderId?: FolderId) => void;
+  moveFilePrompt: (fileId: FileId) => void;
+  renameFilePrompt: (fileId: FileId) => void;
+  renameFolderPrompt: (folderId: FolderId) => void;
 };
 
 const FilesBrowser = ({

--- a/src/CDOIDE/types.ts
+++ b/src/CDOIDE/types.ts
@@ -3,6 +3,9 @@ export type LeftNavElement = {
   component: string;
 };
 
+export type FileId = string;
+export type FolderId = string;
+
 export type ConfigType = {
   showSideBar: boolean;
   showPreview: boolean;
@@ -20,14 +23,14 @@ export type ConfigType = {
 };
 
 export type ProjectFolderType = {
-  id: string;
+  id: FolderId;
   name: string;
   parentId: string;
   open?: boolean;
 };
 
 export type ProjectFileType = {
-  id: string;
+  id: FileId;
   name: string;
   language: string;
   contents: string;


### PR DESCRIPTION
It's better to abstract out the fileId and folderId types.

So added aliases -

```
type FileId = string;
type FolderId = string;
```